### PR TITLE
Update mastodon-share.js

### DIFF
--- a/mastodon-share.js
+++ b/mastodon-share.js
@@ -2,6 +2,7 @@
 // I got the key, I got the secret…
 let key = 'mastodon-instance';
 let instance = localStorage.getItem(key);
+instance = ( null === instance ) ? '' : instance;
 
 // get the link from the DOM
 const button = document.querySelector('.mastodon-share');


### PR DESCRIPTION
Set instance to empty string if null to prevent field from autofilling with `null`.